### PR TITLE
feat(nvim): hide plugs from keybinding list

### DIFF
--- a/.config/nvim/lua/plugins/configs/telescope/pickers.lua
+++ b/.config/nvim/lua/plugins/configs/telescope/pickers.lua
@@ -39,7 +39,7 @@ M.help_tags = function()
 end
 
 M.keymaps = function()
-	b().keymaps({})
+	b().keymaps({ show_plug = false })
 end
 
 M.oldfiles = function()


### PR DESCRIPTION
## Description

This pull request introduces a new feature to improve the user experience in Neovim (nvim). Specifically, it hides the keymaps for which the lhs contains "<Plug>" from the keybinding list. This enhancement makes it easier for users to focus on their own keybindings without clutter from plugins, resulting in a cleaner and more organized workspace.

## Changes Made

Hide the keymaps for which the lhs contains "<Plug>" from the keybinding list.

## Additional Notes

(Optional: Any additional information or context that might be relevant to reviewers)