### PR TITLE
feat(nvim): hide scroll bar at some buftype

### DIFF
--- a/.config/nvim/lua/plugins/configs/nvim-scrollbar.lua
+++ b/.config/nvim/lua/plugins/configs/nvim-scrollbar.lua
@@ -22,6 +22,11 @@ return {
 				Hint = { color = theme.blue },
 				Misc = { color = theme.cyan },
 			},
+			excluded_buftypes = {
+				"terminal",
+				"popup",
+				"nofile",
+			},
 			handlers = {
 				search = true,
 			},

--- a/.config/nvim/lua/plugins/configs/vim-illuminate.lua
+++ b/.config/nvim/lua/plugins/configs/vim-illuminate.lua
@@ -9,6 +9,7 @@ return {
 				"dirvish",
 				"fugitive",
 				"lazy",
+				"markdown",
 				"noice",
 				"prompt",
 				"TelescopePrompt",


### PR DESCRIPTION
## Description

This pull request includes two significant enhancements for Neovim (nvim) to improve the overall user experience.

Changes Made

### Hide Scroll Bar at Some buftype

The commit 7bbc226d23daa65c49b1acca8ba62da151d1540b introduces the feature to hide the scroll bar for specific buffer types (buftype). This enhancement provides a cleaner and distraction-free editing environment for users when working with specific types of buffers.

### Disable Word Highlight in Markdown File

The commit a58a698d59730a644e23fcb1239ceeaffb2e6b40 adds the ability to disable word highlighting specifically for Markdown files. This improvement prevents unnecessary word highlighting in Markdown documents, ensuring a more focused and clutter-free editing experience.
Testing

Comprehensive testing has been conducted to ensure that both features work as intended.

Additional Notes

(Optional: Any additional information or context that might be relevant to reviewers)