### PR TITLE
feat(zsh): Add Default Option for fzf prompt Height

### DIFF
--- a/zprofile.d/10-env.zsh
+++ b/zprofile.d/10-env.zsh
@@ -48,4 +48,4 @@ export GOBIN=${GOPATH}/bin
 export ANDROID_HOME=${HOME}/Library/Android/sdk
 
 # fzf default options
-export FZF_DEFAULT_OPTS='--layout=reverse --tabstop=4 --info=right --no-mouse'
+export FZF_DEFAULT_OPTS='--height=40% --layout=reverse --tabstop=4 --info=right --no-mouse'


### PR DESCRIPTION
## Description

This Pull Request introduces a new feature to improve the user experience in zsh when using fzf. Specifically, it adds a default option for specifying the prompt height when using fzf.

## Changes Made

Added a default option for specifying the prompt height in fzf.
This enhancement allows users to control the height of the fzf prompt without needing to specify it manually each time.

## Additional Notes

(Optional: Any additional information or context that might be relevant to reviewers)