### PR TITLE
feat(nvim): ignore specific pattern on cspell

### DIFF
--- a/.config/cspell/cspell.json
+++ b/.config/cspell/cspell.json
@@ -45,6 +45,14 @@
     "user",
     "vim"
   ],
+  "patterns": [
+    {
+      "name": "Keymap description",
+      "pattern": "\\[[A-Z]\\][a-z]+",
+      "description": "Emphasize key used in keymap"
+    }
+  ],
+  "ignoreRegExpList": ["Keymap description"],
   "languageSettings": [
     {
       "dictionaries": ["lua"],

--- a/.config/cspell/cspell.json
+++ b/.config/cspell/cspell.json
@@ -48,7 +48,7 @@
   "patterns": [
     {
       "name": "Keymap description",
-      "pattern": "\\[[A-Z]\\][a-z]+",
+      "pattern": "[a-z]*\\[[A-Z]\\][a-z]+",
       "description": "Emphasize key used in keymap"
     }
   ],


### PR DESCRIPTION
When using [] to visually highlight key combinations in key mapping descriptions, such as `[G]oto [D]efinition`, spell checking flags the enclosed words like `efinition`.

To mitigate this, I exclude words enclosed within `[]` from spell checking.