### PR TITLE
feat(zsh): add review start alias

### DIFF
--- a/.config/gh-dash/config.yml
+++ b/.config/gh-dash/config.yml
@@ -28,7 +28,7 @@ keybindings:
         tmux new-window -c {{.RepoPath}} '
           tmux rename-window {{.RepoName}}#{{.PrNumber}} &&
           gh pr checkout {{.PrNumber}} &&
-          nvim -c ":Octo pr edit {{.PrNumber}}"
+          nvim -c "let g:review = {{.PrNumber}}"
         '
     - key: v
       command: cd {{.RepoPath}} && code . && gh pr checkout {{.PrNumber}}

--- a/.config/nvim/init.lua
+++ b/.config/nvim/init.lua
@@ -25,3 +25,17 @@ if not vim.g.vscode then
 	-- Plugin configs
 	require("plugins")
 end
+
+-- HACK: Run some Ex commands after loading configs & plugins
+vim.api.nvim_create_autocmd("VimEnter", {
+	callback = function()
+		if vim.g.review then
+			local pn = tonumber(vim.g.review)
+			if not pn then
+				vim.api.nvim_err_writeln("Invalid PR number: " .. vim.g.review)
+				return
+			end
+			vim.cmd(":Octo pr edit" .. vim.g.review)
+		end
+	end,
+})

--- a/zshrc.d/41-functions.zsh
+++ b/zshrc.d/41-functions.zsh
@@ -58,3 +58,7 @@ function zshaddhistory() {
     local line="${1%%$'\n'}"
     [[ ! "$line" =~ "^(cd|jj?|lazygit|la|ll|ls|rm|rmdir)($| )" ]]
 }
+
+function review() {
+    gh pr checkout "$1" && nvim -c ":Octo pr edit "$1""
+}

--- a/zshrc.d/41-functions.zsh
+++ b/zshrc.d/41-functions.zsh
@@ -60,5 +60,5 @@ function zshaddhistory() {
 }
 
 function review() {
-    gh pr checkout "$1" && nvim -c ":Octo pr edit "$1""
+    gh pr checkout "$1" && nvim -c "lua vim.g.review = "$1""
 }


### PR DESCRIPTION
## Description
We can use the `-c` flag to run an Ex command, but it executes before configs/plugins are loaded, which causes the Octo.nvim UI to appear faded. To fix this, set the global variable `g:review` with the `-c` flag, then check for it at the end of init.lua. If `g:review` is set, the Ex command will run, ensuring that the highlight configs load properly.

|w/o trick|w/ trick|
|---|---|
|<img src="https://github.com/user-attachments/assets/c3451e79-f434-498d-a758-fd9f1db35361" />|<img src="https://github.com/user-attachments/assets/e390f932-3f7c-4da5-b3ef-123b4810c173" />|
|<img src="https://github.com/user-attachments/assets/c1c9fb99-febd-494d-a059-8a53dee4c7f6" />|<img src="https://github.com/user-attachments/assets/357f71a2-d632-4c1c-9a59-02a2d77ac276" />|
