### PR TITLE
feat(nvim): remove optional dependencies

### DIFF
--- a/.config/nvim/lua/plugins/configs/avante.lua
+++ b/.config/nvim/lua/plugins/configs/avante.lua
@@ -27,7 +27,6 @@ return {
 	},
 	dependencies = {
 		"nvim-treesitter/nvim-treesitter",
-		"stevearc/dressing.nvim",
 		"nvim-lua/plenary.nvim",
 		"MunifTanjim/nui.nvim",
 		"nvim-telescope/telescope.nvim",
@@ -47,13 +46,6 @@ return {
 					use_absolute_path = true,
 				},
 			},
-		},
-		{
-			"MeanderingProgrammer/render-markdown.nvim",
-			opts = {
-				file_types = { "markdown", "Avante" },
-			},
-			ft = { "markdown", "Avante" },
 		},
 	},
 }


### PR DESCRIPTION
## Description

`dressing.nvim` is not actually an optional dependency, but it works without it.